### PR TITLE
Set numpy version to x.x

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - setuptools
   run:
     - python
-    - numpy
+    - numpy x.x
     - pandas
     - netcdf4
     - scipy


### PR DESCRIPTION
Suspect this is causing problems packaging wrf-python with numpy 1.12.  

See conda-forge/wrf-python-feedstock#2
