### PR TITLE
Add setuptools dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ A feedstock is made up of a conda recipe (the instructions on what and how to bu
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
 [CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.org/) it is possible to build and upload installable
+and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
 packages to the [conda-forge](https://anaconda.org/conda-forge)
 [Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
@@ -21,6 +21,7 @@ requirements:
     - python >=3.6
     - numpy >=1.14
     - pandas >=0.24
+    - setuptools
 
 test:
   imports:


### PR DESCRIPTION
A build of one of my packages, which depends on `xarray`, [failed](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=103605&view=logs&j=1bf226d3-0e2f-52d8-fa93-7d9e633347b3&t=ec8d466d-e3b4-5115-4f06-222398f91e6c) because `setuptools` doesn't get installed alongside `xarray`, yet `xarray` depends on `setuptools`. On the conda-forge gitter channel it was then suggested that the `xarray` recipe should explicitly list `setuptools` as a run dependency. This is what this PR does.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
